### PR TITLE
Revert "Bump @types/express from 4.17.9 to 4.17.10 (#28)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/bcrypt": "^3.0.0",
     "@types/ejs": "^3.0.5",
-    "@types/express": "^4.17.10",
+    "@types/express": "^4.17.9",
     "@types/express-session": "^1.17.3",
     "@types/passport": "^1.0.5",
     "@typescript-eslint/parser": "^4.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,10 +276,10 @@
   dependencies:
     "@types/express" "*"
 
-"@types/express@*", "@types/express@^4.17.10":
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.10.tgz#850fe07d6d887412d522a4295fb84a685e69f683"
-  integrity sha512-GRwKdE+iV6mA8glCvQ7W5iaoIhd6u1HDsNTF76UPRi7T89SLjOfeCLShVmQSgpXzcpf3zgcz2SbMiCcjnYRRxQ==
+"@types/express@*", "@types/express@^4.17.9":
+  version "4.17.9"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.9.tgz#f5f2df6add703ff28428add52bdec8a1091b0a78"
+  integrity sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"


### PR DESCRIPTION
This reverts commit 41c49ce0

# Description

Please include a summary of your changes and which issue you fixed. Please also include relevant information and context.
List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] Checkstyle build-step is running without errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings