### PR TITLE
Rollback sqlite from v5.0.1 to v5.0.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 2.7
       - name: Install Yarn
         run: npm install -g yarn
       - name: Install modules
@@ -34,9 +31,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 2.7
       - name: Install Yarn
         run: npm install -g yarn
       - name: Install modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,11 @@ FROM node:lts-alpine as build-stage
 WORKDIR /usr/src/app/
 COPY . .
 
-# install build dependencies
-RUN apk --no-cache --virtual build-dependencies add \
-    python2 \
-    make \
-    g++ \
-    bash
-
 # install dependencies
 RUN yarn install --frozen-lockfile
 
 # build and cleanup afterwords
 RUN yarn build && npm prune --production
-
-# delete build-dependencies
-RUN apk del build-dependencies
 
 ### production stage
 # base image settings

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "passport": "^0.4.1",
     "passport-custom": "^1.1.1",
     "sequelize": "^6.3.5",
-    "sqlite3": "^5.0.1"
+    "sqlite3": "5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6383,12 +6383,12 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sqlite3@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.0.1.tgz#d5b58c8d1568bbaf13062eb9465982f36324f78a"
-  integrity sha512-kh2lTIcYNfmVcvhVJihsYuPj9U0xzBbh6bmqILO2hkryWSC9RRhzYmkIDtJkJ+d8Kg4wZRJ0T1reyHUEspICfg==
+sqlite3@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.0.0.tgz#1bfef2151c6bc48a3ab1a6c126088bb8dd233566"
+  integrity sha512-rjvqHFUaSGnzxDy2AHCwhHy6Zp6MNJzCPGYju4kD8yi6bze4d1/zMTg6C7JI49b7/EM7jKMTvyfN/4ylBKdwfw==
   dependencies:
-    node-addon-api "^3.0.0"
+    node-addon-api "2.0.0"
     node-pre-gyp "^0.11.0"
   optionalDependencies:
     node-gyp "3.x"


### PR DESCRIPTION
# Description

Rolling back SQLite from version 5.0.1 to version 5.0.0 due to some build issues with Windows.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] Checkstyle build-step is running without errors
- [X] My changes generate no new warnings